### PR TITLE
Include ckanext-medicallybame extension in the setup

### DIFF
--- a/example/build.sh
+++ b/example/build.sh
@@ -26,3 +26,10 @@ pip install -r lintol-requirements.txt
 python setup.py install
 python setup.py develop
 cd ..
+
+git clone https://${GITHUB_TOKEN}:x-oauth-basic@github.com/dkayee/ckanext-medicallybame.git
+cd ckanext-medicallybame
+pip install -r requirements.txt
+python setup.py install
+python setup.py develop
+cd ..

--- a/example/values.yaml
+++ b/example/values.yaml
@@ -19,6 +19,7 @@ ckan-core:
     - datapusher
     # validation
     - oauth2provider
+    - medicallybame
   postgres:
     password: TEST
     dataStoreRoPassword: TEST

--- a/subcharts/ckan-core/values.yaml
+++ b/subcharts/ckan-core/values.yaml
@@ -36,6 +36,7 @@ plugins:
   - validation
   - oauth2provider
   - harvest
+  - medicallybame
 
   lintol:
     token: TOKEN


### PR DESCRIPTION
# Description

Extends the `example/build.sh` script to include the `ckanext-medicallybame` CKAN extension which updates the theme for CKAN data portal.

@philtweir Issues mentioned in  https://github.com/dkayee/ckanext-medicallybame/issues/1#issue-736525627 has been addressed. You'd find latest changes pushed to the `master` branch and the `develop` branch has been deleted. Do note though that I was unable to run your setup, Kubernetes and helm are not forte. However, changes were tested with the `medicallybame-setup`.
